### PR TITLE
feature: expose icon16 logo to detect extension presence

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "Apiary Browser Extension",
   "short_name": "Apiary",
   "description": "Apiary Browser Extension",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,5 +26,8 @@
   "permissions": [
     "http://*/*",
     "https://*/*"
+  ],
+ "web_accessible_resources": [
+    "icon16.png"
   ]
 }


### PR DESCRIPTION
This PR will expose the (mandatory) 16x16 logo, so I can query it from an external webpage and use its presence as a sign that we have the extension installed.