### PR TITLE
Add basic detection mechanism

### DIFF
--- a/extension/detect.js
+++ b/extension/detect.js
@@ -1,0 +1,3 @@
+const isInstalledNode = document.createElement('div');
+isInstalledNode.id = 'apiary-browser-extension';
+document.body.appendChild(isInstalledNode);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "Apiary Browser Extension",
   "short_name": "Apiary",
   "description": "Apiary Browser Extension",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,6 +23,18 @@
     ],
     "persistent": false
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://localhost:*/*",
+        "*://*.apiary.io/*",
+        "*://*.apiary-staging.in/*"
+      ],
+      "js": [
+        "build/detect.js"
+      ]
+    }
+  ],
   "permissions": [
     "http://*/*",
     "https://*/*"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "build:extension": "webpack -p --module-bind js=babel-loader --devtool=source-map ./extension/extension.js ./extension/build/extension.js",
+    "build:extension": "webpack -p --module-bind js=babel-loader --devtool=source-map extension=./extension/extension.js detect=./extension/detect.js --output-path='./extension/build' --output-filename='[name].js'",
     "test:iframe": "karma start ./karma.iframe.conf.js",
     "test:chrome": "karma start ./karma.chrome.conf.js",
     "test": "npm run test:chrome && npm run test:iframe",

--- a/src/Seed/__tests__/chrome/unit/Seed.unit.test.js
+++ b/src/Seed/__tests__/chrome/unit/Seed.unit.test.js
@@ -92,4 +92,10 @@ describe('Component interface test', () => {
       })
     });
   });
+
+  describe('extension detection', () => {
+    it('should find a secret DOM node in the page', () => {
+      expect(document.getElementById('apiary-browser-extension')).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
This PR will implement a basic detect mechanism for our Chrome Extension, by injecting a particular DOM node. It's the suggested way by Google, so I guess it's good to go.