### PR TITLE
Fix match on content script for localhost

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,7 +26,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://localhost:*/*",
+        "*://localhost/*",
         "*://*.apiary.io/*",
         "*://*.apiary-staging.in/*"
       ],


### PR DESCRIPTION
When I tried to submit the extension to Chrome Developer Dashboard I got an error where the match was invalid, refusing to load and publish it.

Fun fact: Chrome is still loading the extension, so it seems to really be just a store check.