### PR TITLE
Color the extension icon when ready

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -7,9 +7,13 @@ const chan = Channel.build({
   scope: 'chromeScope',
   remote: 'ping',
   onReady: () => {
-    chan.bind('ping', () => {
-      return { pong: true };
+    chan.bind('ping', (trans) => {
+      trans.delayReturn(true);
+      chrome.tabs.getSelected(null, (tab) => {
+        window.chrome.pageAction.show(tab.id);
+        trans.complete({ pong: true });
     });
+  });
   }
 });
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,6 +10,9 @@
     "48": "icon48.png",
     "128": "icon128.png"
   },
+  "page_action": {
+    "default_popup": "popup.html"
+  },
   "externally_connectable": {
     "matches": [
       "*://localhost:*/*",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Apiary Browser Extension</title>
+  <meta charset=utf8>
+  <style>
+    html {
+      width: 350px;
+      text-align: center;
+    }
+  </style>
+</head>
+
+<body>
+  <p>Apiary extension is ready for requests.</p>
+</body>
+
+</html>


### PR DESCRIPTION
This pull request will add a small pie on the extension.

Basically, instead of having this icon all the time:

![image](https://cloud.githubusercontent.com/assets/1416224/26488746/f1ff5732-4204-11e7-9fac-8b1c3093ee72.png)

The extension will color its icon when it detects that the link with Apiary is in place:

![image](https://cloud.githubusercontent.com/assets/1416224/26488762/02dcfaaa-4205-11e7-9ff5-881b1c009493.png)

as well as showing a little stupid message when you click on it

![image](https://cloud.githubusercontent.com/assets/1416224/26488784/11770db2-4205-11e7-9761-1dcbe6d24be5.png)

