### PR TITLE
fix(js-agent): fix inconsistencies in origin subdomain and port

### DIFF
--- a/src/JsAgent/JsAgent.js
+++ b/src/JsAgent/JsAgent.js
@@ -40,12 +40,12 @@ Apiary.createAgent = function createAgent({ subdomains }) {
   subdomains.forEach((subdomain) => {
 
     const origin = new URI({
-      protocol: 'http',
+      protocol: 'https',
       hostname: DOMAIN,
-    }).subdomain(`docs.${subdomain}`)
+    }).subdomain(`${subdomain}.docs`)
 
-    if (PORT){
-      origin.port(PORT);
+    if (SSL_PORT){
+      origin.port(SSL_PORT);
     }
 
     const jsapiOrigin = new URI({


### PR DESCRIPTION
Apiarys documentation urls have changed. This commit compansates for that.

http://apiproject.docs.apiary.io -> https://apiproject.docs.apiary.io

Also the protocol changes from HTTP to HTTPS.