### PR TITLE
feat(extension): exposing extension icon as a web resource

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "Apiary Browser Extension",
   "short_name": "Apiary",
   "description": "Apiary Browser Extension",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",
@@ -16,8 +16,10 @@
   "externally_connectable": {
     "matches": [
       "*://localhost:*/*",
+      "*://*.apiary.dev:*/*",
       "*://*.apiary.io/*",
-      "*://*.apiary-staging.in/*"
+      "*://*.apiary-staging.in/*",
+      "*://*.apicurious.com/*"
     ]
   },
   "background": {
@@ -31,7 +33,8 @@
       "matches": [
         "*://localhost/*",
         "*://*.apiary.io/*",
-        "*://*.apiary-staging.in/*"
+        "*://*.apiary-staging.in/*",
+        "*://*.apicurious.com/*"
       ],
       "js": [
         "build/detect.js"
@@ -41,5 +44,8 @@
   "permissions": [
     "http://*/*",
     "https://*/*"
+  ],
+  "web_accessible_resources": [
+    "icon16.png"
   ]
 }


### PR DESCRIPTION
Also added current staging domain into content_scripts.

Closes https://trello.com/c/40WJahv2/410-release-apiary-extension-with-bugfix-related-to-detecting-it