### PR TITLE
fix(extension): resolve promise for any status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ been testing it a lot on different http edge cases. You can have a look to
 [node-hamms][8] repository
 
 The returned promise will resolve with an [Axios Response Object][9], or rejected
-with an error, if any occurs during the operation
+according to the [Axios Handling Errors][10] rules.
 
 ### Low level method
 
@@ -117,3 +117,4 @@ const promise = seed.sendMessage({method, params});
 [7]: https://github.com/mzabriskie/axios#request-config
 [8]: https://github.com/apiaryio/node-hamms
 [9]: https://github.com/mzabriskie/axios#response-schema
+[10]: https://github.com/axios/axios#handling-errors

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ const promise = seed.sendMessage({method, params});
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API
 [5]: https://github.com/mozilla/jschannel
 [6]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
-[7]: https://github.com/mzabriskie/axios#request-config
+[7]: https://github.com/axios/axios#request-config
 [8]: https://github.com/apiaryio/node-hamms
-[9]: https://github.com/mzabriskie/axios#response-schema
+[9]: https://github.com/axios/axios#response-schema
 [10]: https://github.com/axios/axios#handling-errors

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -1,6 +1,10 @@
 const axios = require('axios');
 const Channel = require('jschannel');
 
+const instance = axios.create({
+  validateStatus: () => true
+});
+
 const chan = Channel.build({
   window: window,
   origin: '*',
@@ -21,7 +25,7 @@ const chan = Channel.build({
 chan.bind('httpRequest', (trans, requestOptions) => {
   trans.delayReturn(true);
 
-  axios(requestOptions)
+  instance(requestOptions)
     .then(trans.complete)
     .catch((err) => {
       let errorCopy = JSON.parse(JSON.stringify(err));

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "Apiary Browser Extension",
   "short_name": "Apiary",
   "description": "Apiary Browser Extension",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "axios": "^0.16.0",
     "jschannel": "^1.0.2",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "=15.4.2",
+    "react-dom": "=15.4.2",
     "urijs": "^1.18.10"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "react-dom": "^15.4.2",
     "urijs": "^1.18.10"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apiaryio/console-proxy.git"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/Seed/__tests__/chrome/hamms/statusCode.test.js
+++ b/src/Seed/__tests__/chrome/hamms/statusCode.test.js
@@ -26,6 +26,7 @@ describe('Status Codes', () => {
   const statuses = [
     { code: 200, text: 'OK' },
     { code: 201, text: 'Created' },
+    { code: 204, text: 'No Content' },
     { code: 400, text: 'Bad Request' },
     { code: 401, text: 'Unauthorized' },
     { code: 403, text: 'Forbidden' },
@@ -46,7 +47,8 @@ describe('Status Codes', () => {
       };
 
       seed.request({ url: `http://localhost:3001/statuses/${item.code}` })
-        .then(handleResponse, (err) => { handleResponse(err.response); });
+        .then(handleResponse,
+              done.fail.bind(this, new Error('This promise should not have been rejected')));
     }, 5000);
   });
 });

--- a/src/Seed/__tests__/iframe/hamms/statusCode.test.js
+++ b/src/Seed/__tests__/iframe/hamms/statusCode.test.js
@@ -28,6 +28,7 @@ describe('Status Codes', () => {
   const statuses = [
     { code: 200, text: 'OK' },
     { code: 201, text: 'Created' },
+    { code: 204, text: 'No Content' },
     { code: 400, text: 'Bad Request' },
     { code: 401, text: 'Unauthorized' },
     { code: 403, text: 'Forbidden' },
@@ -48,7 +49,8 @@ describe('Status Codes', () => {
       };
 
       seed.request({ url: `http://localhost:3001/statuses/${item.code}` })
-        .then(handleResponse, (err) => { handleResponse(err.response); });
+        .then(handleResponse,
+              done.fail.bind(this, new Error('This promise should not have been rejected')));
     }, 5000);
   });
 });


### PR DESCRIPTION
Change the Apiary Chrome extension request() behavior
so that it resolves its promise for any HTTP status code responses.
This is the HTML5 fetch() spec behavior.